### PR TITLE
Fix presets/Verbose (Beam Search).txt

### DIFF
--- a/presets/Verbose (Beam Search).txt
+++ b/presets/Verbose (Beam Search).txt
@@ -1,6 +1,6 @@
 num_beams=10
 min_length=200
-length_penalty =1.4
+length_penalty=1.4
 no_repeat_ngram_size=2
 early_stopping=True
 temperature=0.7


### PR DESCRIPTION
Just a quick fix that removes an erroneous space between "length_penalty" and "=" (doesn't affect Python, but makes it possible to source the file from Bash, e. g. to use the variables with API calls!)